### PR TITLE
fix: remove mandatory upload coverage

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,5 +20,4 @@ jobs:
     - name: Upload coverage
       uses: codecov/codecov-action@v4
       with:
-        fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Description
This removes the CI fails for reasons if there is not token or correct config.
The default value of the action in `fail_ci_if_error` is false.


Checks passed.

