### PR TITLE
feat: add lisanAI to editors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@dnd-kit/modifiers": "^7.0.0",
         "@dnd-kit/sortable": "^8.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@edunext/frontend-essentials": "4.6.0",
         "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
         "@edx/frontend-component-ai-translations": "^2.0.0",
         "@edx/frontend-component-footer": "^13.0.2",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@dnd-kit/modifiers": "^7.0.0",
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@edunext/frontend-essentials": "4.6.0",
     "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
     "@edx/frontend-component-ai-translations": "^2.0.0",
     "@edx/frontend-component-footer": "^13.0.2",

--- a/src/CourseAuthoringPage.jsx
+++ b/src/CourseAuthoringPage.jsx
@@ -6,6 +6,8 @@ import {
   useLocation,
 } from 'react-router-dom';
 import { StudioFooter } from '@edx/frontend-component-footer';
+import { getConfig } from '@edx/frontend-platform';
+import { LisanAI } from '@edunext/frontend-essentials';
 import Header from './header';
 import { fetchCourseDetail } from './data/thunks';
 import { useModel } from './generic/model-store';
@@ -68,6 +70,7 @@ const CourseAuthoringPage = ({ courseId, children }) => {
   }
   return (
     <div className={pathname.includes('/editor/') ? '' : 'bg-light-200'}>
+      {getConfig().LISAN_AI_ENABLED && (<LisanAI clientId={getConfig().LISAN_AI_CLIENT_ID} />)}
       {/* While V2 Editors are temporarily served from their own pages
       using url pattern containing /editor/,
       we shouldn't have the header and footer on these pages.


### PR DESCRIPTION
## Description

feat: add lisanAI to editors

{/* While V2 Editors are temporarily served from their own pages using url pattern containing /editor/,
we shouldn't have the header and footer on these pages. This functionality will be removed in TNL-9591 */}


## Testing instructions

Go to editor and check lisan.

- Tested in local.

[Screencast from 26-06-25 14:35:28.webm](https://github.com/user-attachments/assets/6a91aba8-9106-43c6-b482-892b9664b0da)

- Tested in stage

[Screencast from 26-06-25 14:57:59.webm](https://github.com/user-attachments/assets/c74745dc-0d8f-43e2-afb4-ea3edc63a97b)


## Other information

**jira story** https://edunext.atlassian.net/browse/FUTUREX-1183?atlOrigin=eyJpIjoiZjFkOTA4NzQyZTgyNGZhN2I5ZjE1MjVhMDM3MTVlNjEiLCJwIjoiaiJ9